### PR TITLE
Epic Loot Release 0.10.2:

### DIFF
--- a/EpicLoot-UnityLib/src/AugmentUI.cs
+++ b/EpicLoot-UnityLib/src/AugmentUI.cs
@@ -59,7 +59,9 @@ namespace EpicLoot_UnityLib
                 var augmentChoices = 2;
                 var featureValues = EnchantingTableUI.instance.SourceTable.GetFeatureCurrentValue(EnchantingFeature.Augment);
                 if (!float.IsNaN(featureValues.Item1))
+                {
                     augmentChoices = (int)featureValues.Item1;
+                }
 
                 var colorPre = augmentChoices > 2 ? "<color=#EAA800>" : "";
                 var colorPost = augmentChoices > 2 ? "</color>" : "";
@@ -91,7 +93,9 @@ namespace EpicLoot_UnityLib
                 {
                     var rightStickAxis = ZInput.GetJoyRightStickY();
                     if (Mathf.Abs(rightStickAxis) > 0.5f)
+                    {
                         AvailableEffectsScrollbar.value = Mathf.Clamp01(AvailableEffectsScrollbar.value + rightStickAxis * -0.1f);
+                    }
                 }
             }
 
@@ -105,7 +109,9 @@ namespace EpicLoot_UnityLib
                 AvailableItems.ForeachElement((i, e) =>
                 {
                     if (!e.IsSelected())
+                    {
                         return;
+                    }
                     e.SetItem(e.GetListElement());
                     e.Refresh();
                 });
@@ -131,7 +137,9 @@ namespace EpicLoot_UnityLib
             else
             {
                 if (!AugmentSelectors.Any(x => x.isOn))
+                {
                     SelectAugmentIndex(-1);
+                }
             }
         }
 
@@ -183,9 +191,14 @@ namespace EpicLoot_UnityLib
                 var featureValues = EnchantingTableUI.instance.SourceTable.GetFeatureCurrentValue(EnchantingFeature.Augment);
                 var reenchantCostReduction = float.IsNaN(featureValues.Item2) ? 0 : featureValues.Item2;
                 if (reenchantCostReduction > 0)
-                    CostLabel.text = Localization.instance.Localize($"$mod_epicloot_augmentcost <color=#EAA800>(-{reenchantCostReduction}% $item_coins!)</color>");
+                {
+                    CostLabel.text = Localization.instance.Localize($"$mod_epicloot_augmentcost " +
+                        $"<color=#EAA800>(-{reenchantCostReduction}% $item_coins!)</color>");
+                }
                 else
+                {
                     CostLabel.text = Localization.instance.Localize("$mod_epicloot_augmentcost");
+                }
 
                 var canAfford = LocalPlayerCanAffordCost(cost);
                 var featureUnlocked = EnchantingTableUI.instance.SourceTable.IsFeatureUnlocked(EnchantingFeature.Augment);
@@ -219,16 +232,17 @@ namespace EpicLoot_UnityLib
                     return;
                 }
 
-                var inventory = player.GetInventory();
                 foreach (var costElement in cost)
                 {
                     var costItem = costElement.GetItem();
-                    inventory.RemoveItem(costItem.m_shared.m_name, costItem.m_stack);
+                    InventoryManagement.Instance.RemoveItem(costItem.m_shared.m_name, costItem.m_stack);
                 }
             }
 
             if (_choiceDialog != null)
+            {
                 Destroy(_choiceDialog);
+            }
 
             _choiceDialog = AugmentItem(item, _augmentIndex);
 
@@ -250,12 +264,16 @@ namespace EpicLoot_UnityLib
             {
                 var selector = AugmentSelectors[index];
                 if (selector == null)
+                {
                     continue;
+                }
 
                 selector.SetIsOnWithoutNotify(index == 0);
                 selector.gameObject.SetActive(item != null && index < augmentableEffects.Count);
                 if (!selector.gameObject.activeSelf)
+                {
                     continue;
+                }
 
                 var selectorText = selector.GetComponentInChildren<Text>();
                 if (selectorText != null)
@@ -266,7 +284,9 @@ namespace EpicLoot_UnityLib
             }
 
             if (item == null)
+            {
                 AvailableEffectsText.text = string.Empty;
+            }
 
             _augmentIndex = 0;
             OnAugmentIndexChanged();
@@ -282,12 +302,16 @@ namespace EpicLoot_UnityLib
             {
                 var selector = AugmentSelectors[index];
                 if (selector == null)
+                {
                     continue;
+                }
 
                 selector.SetIsOnWithoutNotify(index == _augmentIndex);
                 selector.gameObject.SetActive(item != null && index < augmentableEffects.Count);
                 if (!selector.gameObject.activeSelf)
+                {
                     continue;
+                }
 
                 var selectorText = selector.GetComponentInChildren<Text>();
                 if (selectorText != null)

--- a/EpicLoot-UnityLib/src/ConvertUI.cs
+++ b/EpicLoot-UnityLib/src/ConvertUI.cs
@@ -31,16 +31,11 @@ namespace EpicLoot_UnityLib
 
         public int GetMax()
         {
-            var player = Player.m_localPlayer;
-            if (player == null)
-                return 0;
-
-            var inventory = player.GetInventory();
-            var min = int.MaxValue;
+            int min = int.MaxValue;
             foreach (var cost in Cost)
             {
-                var count = inventory.CountItems(cost.Item.m_shared.m_name);
-                var canMake = Mathf.FloorToInt(count / (float)cost.Amount);
+                int count = InventoryManagement.Instance.CountItem(cost.Item);
+                int canMake = Mathf.FloorToInt(count / (float)cost.Amount);
                 min = Mathf.Min(min, canMake);
             }
 
@@ -175,28 +170,14 @@ namespace EpicLoot_UnityLib
 
             Cancel();
 
-            var player = Player.m_localPlayer;
-            var inventory = player.GetInventory();
             foreach (var costElement in cost)
             {
-                var costItem = costElement.GetItem();
-                inventory.RemoveItem(costItem.m_shared.m_name, costItem.m_stack);
+                InventoryManagement.Instance.RemoveItem(costElement.GetItem());
             }
 
             foreach (var productElement in allProducts)
             {
-                var product = productElement.GetItem();
-                if (inventory.CanAddItem(product))
-                {
-                    inventory.AddItem(product);
-                    player.Message(MessageHud.MessageType.TopLeft, $"$msg_added {product.m_shared.m_name}", product.m_stack, product.GetIcon());
-                }
-                else
-                {
-                    var itemDrop = ItemDrop.DropItem(product, product.m_stack, player.transform.position + player.transform.forward + player.transform.up, player.transform.rotation);
-                    itemDrop.GetComponent<Rigidbody>().velocity = Vector3.up * 5f;
-                    player.Message(MessageHud.MessageType.TopLeft, $"$msg_dropped {itemDrop.m_itemData.m_shared.m_name} $mod_epicloot_sacrifice_inventoryfullexplanation", itemDrop.m_itemData.m_stack, itemDrop.m_itemData.GetIcon());
-                }
+                InventoryManagement.Instance.GiveItem(productElement.GetItem());
             }
 
             DeselectAll();

--- a/EpicLoot-UnityLib/src/DisenchantUI.cs
+++ b/EpicLoot-UnityLib/src/DisenchantUI.cs
@@ -40,12 +40,9 @@ namespace EpicLoot_UnityLib
             if (!LocalPlayerCanAffordCost(cost))
                 return;
 
-            var player = Player.m_localPlayer;
-            var inventory = player.GetInventory();
             foreach (var costElement in cost)
             {
-                var costItem = costElement.GetItem();
-                inventory.RemoveItem(costItem.m_shared.m_name, costItem.m_stack);
+                InventoryManagement.Instance.RemoveItem(costElement.GetItem());
             }
 
             var bonusItems = DisenchantItem(item);

--- a/EpicLoot-UnityLib/src/EnchantUI.cs
+++ b/EpicLoot-UnityLib/src/EnchantUI.cs
@@ -147,7 +147,9 @@ namespace EpicLoot_UnityLib
             Cancel();
 
             if (selectedItem?.Item1.GetItem() == null)
+            {
                 return;
+            }
 
             var item = selectedItem.Item1.GetItem();
             var cost = GetEnchantCost(item, _rarity);
@@ -161,16 +163,17 @@ namespace EpicLoot_UnityLib
                     return;
                 }
 
-                var inventory = player.GetInventory();
                 foreach (var costElement in cost)
                 {
                     var costItem = costElement.GetItem();
-                    inventory.RemoveItem(costItem.m_shared.m_name, costItem.m_stack);
+                    InventoryManagement.Instance.RemoveItem(costItem.m_shared.m_name, costItem.m_stack);
                 }
             }
 
             if (_successDialog != null)
+            {
                 Destroy(_successDialog);
+            }
 
             DeselectAll();
             Lock();

--- a/EpicLoot-UnityLib/src/EnchantingTableUIPanelBase.cs
+++ b/EpicLoot-UnityLib/src/EnchantingTableUIPanelBase.cs
@@ -180,16 +180,19 @@ namespace EpicLoot_UnityLib
 
         protected static bool LocalPlayerCanAffordCost(List<InventoryItemListElement> cost)
         {
-            var player = Player.m_localPlayer;
-            if (player.NoCostCheat())
+            if (Player.m_localPlayer.NoCostCheat())
+            {
                 return true;
+            }
 
-            var inventory = player.GetInventory();
             foreach (var element in cost)
             {
                 var item = element.GetItem();
-                if (inventory.CountItems(item.m_shared.m_name) < item.m_stack)
+
+                if (!InventoryManagement.Instance.HasItem(item))
+                {
                     return false;
+                }
             }
 
             return true;
@@ -197,30 +200,10 @@ namespace EpicLoot_UnityLib
 
         protected static void GiveItemsToPlayer(List<InventoryItemListElement> sacrificeProducts)
         {
-            var player = Player.m_localPlayer;
-            var inventory = player.GetInventory();
-
             foreach (var sacrificeProduct in sacrificeProducts)
             {
                 var item = sacrificeProduct.GetItem();
-                do
-                {
-                    var itemToAdd = item.Clone();
-                    itemToAdd.m_stack = Mathf.Min(item.m_stack, item.m_shared.m_maxStackSize);
-                    item.m_stack -= itemToAdd.m_stack;
-                    //Debug.LogWarning($"Adding item: {itemToAdd.m_shared.m_name} x{itemToAdd.m_stack} (remaining:{item.m_stack})");
-                    if (inventory.CanAddItem(itemToAdd))
-                    {
-                        inventory.AddItem(itemToAdd);
-                        player.Message(MessageHud.MessageType.TopLeft, $"$msg_added {itemToAdd.m_shared.m_name}", itemToAdd.m_stack, itemToAdd.GetIcon());
-                    }
-                    else
-                    {
-                        var itemDrop = ItemDrop.DropItem(itemToAdd, itemToAdd.m_stack, player.transform.position + player.transform.forward + player.transform.up, player.transform.rotation);
-                        itemDrop.GetComponent<Rigidbody>().velocity = Vector3.up * 5f;
-                        player.Message(MessageHud.MessageType.TopLeft, $"$msg_dropped {itemDrop.m_itemData.m_shared.m_name} $mod_epicloot_sacrifice_inventoryfullexplanation", itemDrop.m_itemData.m_stack, itemDrop.m_itemData.GetIcon());
-                    }
-                } while (item.m_stack > 0);
+                InventoryManagement.Instance.GiveItem(item);
             }
         }
     }

--- a/EpicLoot-UnityLib/src/InventoryManagement.cs
+++ b/EpicLoot-UnityLib/src/InventoryManagement.cs
@@ -1,0 +1,180 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace EpicLoot_UnityLib;
+
+public class InventoryManagement
+{
+    static InventoryManagement() { }
+    private InventoryManagement() { }
+    private static readonly InventoryManagement _instance = new InventoryManagement();
+
+    public static InventoryManagement Instance
+    {
+        get => _instance;
+    }
+
+    private void SendMessage(string message, int amount, Sprite icon)
+    {
+        Player.m_localPlayer.Message(MessageHud.MessageType.TopLeft,
+            message, amount, icon);
+    }
+
+    private Inventory GetInventory()
+    {
+        Player player = Player.m_localPlayer;
+
+        if (player != null)
+        {
+            return player.GetInventory();
+        }
+
+        return null;
+    }
+
+    public List<ItemDrop.ItemData> GetAllItems()
+    {
+        Inventory inventory = GetInventory();
+        if (inventory != null)
+        {
+            return inventory.GetAllItems();
+        }
+
+        return null;
+    }
+
+    public bool HasItem(ItemDrop.ItemData item)
+    {
+        Inventory inventory = GetInventory();
+
+        if (inventory == null || inventory.CountItems(item.m_shared.m_name) < item.m_stack)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public int CountItem(ItemDrop.ItemData item)
+    {
+        return CountItem(item.m_shared.m_name);
+    }
+
+    public int CountItem(string item)
+    {
+        Inventory inventory = GetInventory();
+
+        if (inventory == null)
+        {
+            return 0;
+        }
+
+        return inventory.CountItems(item);
+    }
+
+    public void GiveItem(string item, int amount)
+    {
+        Debug.Log($"Attempting to give item {item} with amount {amount}");
+        Inventory inventory = GetInventory();
+        if (inventory != null)
+        {
+            AddItem(ref inventory, item, amount);
+        }
+        else
+        {
+            DropItem(item, amount);
+        }
+    }
+
+    public bool GiveItem(ItemDrop.ItemData item)
+    {
+        Debug.Log($"Attempting to give itemdata {item.m_shared.m_name} with amount {item.m_stack}");
+        Inventory inventory = GetInventory();
+
+        do
+        {
+            var itemToAdd = item.Clone();
+            itemToAdd.m_stack = Mathf.Min(item.m_stack, item.m_shared.m_maxStackSize);
+            item.m_stack -= itemToAdd.m_stack;
+
+            if (inventory != null)
+            {
+                AddItem(ref inventory, itemToAdd);
+            }
+            else
+            {
+                DropItem(itemToAdd);
+            }
+        } while (item.m_stack > 0);
+
+        return true;
+    }
+
+    private void AddItem(ref Inventory inventory, string item, int amount)
+    {
+        var result = inventory.AddItem(item, amount, 1, 0, 0, string.Empty);
+
+        if (result == null)
+        {
+            DropItem(item, amount);
+        }
+    }
+
+    private void AddItem(ref Inventory inventory, ItemDrop.ItemData item)
+    {
+        if (inventory.AddItem(item))
+        {
+            SendMessage($"$msg_added {item.m_shared.m_name}", item.m_stack, item.GetIcon());
+        }
+        else
+        {
+            DropItem(item);
+        }
+    }
+
+    private void DropItem(string item, int amount)
+    {
+        Debug.Log($"Attempting to drop item {item} with amount {amount}");
+        Player player = Player.m_localPlayer;
+        var prefab = ObjectDB.instance.GetItemPrefab(item);
+
+        if (prefab != null)
+        {
+            var go = GameObject.Instantiate(prefab,
+                player.transform.position + player.transform.forward + player.transform.up,
+                player.transform.rotation);
+
+            var itemdrop = go.GetComponent<ItemDrop>();
+            itemdrop.SetStack(amount);
+            itemdrop.GetComponent<Rigidbody>().velocity = Vector3.up * 5f;
+
+            SendMessage($"$msg_dropped {itemdrop.m_itemData.m_shared.m_name}",
+                itemdrop.m_itemData.m_stack, itemdrop.m_itemData.GetIcon());
+        }
+    }
+
+    private void DropItem(ItemDrop.ItemData item)
+    {
+        Debug.Log($"Attempting to drop itemdata {item.m_shared.m_name} with amount {item.m_stack}");
+        Player player = Player.m_localPlayer;
+        var itemDrop = ItemDrop.DropItem(item, item.m_stack,
+            player.transform.position + player.transform.forward + player.transform.up,
+            player.transform.rotation);
+        itemDrop.GetComponent<Rigidbody>().velocity = Vector3.up * 5f;
+
+        SendMessage($"$msg_dropped {itemDrop.m_itemData.m_shared.m_name}",
+            itemDrop.m_itemData.m_stack, itemDrop.m_itemData.GetIcon());
+    }
+
+    public void RemoveItem(ItemDrop.ItemData item)
+    {
+        RemoveItem(item.m_shared.m_name, item.m_stack);
+    }
+
+    public void RemoveItem(string item, int amount)
+    {
+        Inventory inventory = GetInventory();
+
+        inventory.RemoveItem(item, amount);
+    }
+}

--- a/EpicLoot-UnityLib/src/MultiSelectItemListElement.cs
+++ b/EpicLoot-UnityLib/src/MultiSelectItemListElement.cs
@@ -281,10 +281,10 @@ namespace EpicLoot_UnityLib
                 var quantityText = string.Format(ReadOnly ? ReadOnlyQuantityFormat : TotalQuantityFormat, _item.GetMax());
                 if (CheckPlayerInventory)
                 {
-                    var inventory = Player.m_localPlayer.GetInventory();
-                    var hasEnough = inventory.CountItems(_item.GetItem().m_shared.m_name) >= _item.GetItem().m_stack;
-                    if (!hasEnough)
+                    if (!InventoryManagement.Instance.HasItem(_item.GetItem()))
+                    {
                         quantityText = $"<color=red>{quantityText}</color>";
+                    }
                 }
                 ItemTotalQuantity.text = quantityText;
             }

--- a/EpicLoot-UnityLib/src/SacrificeUI.cs
+++ b/EpicLoot-UnityLib/src/SacrificeUI.cs
@@ -48,11 +48,9 @@ namespace EpicLoot_UnityLib
                 }
             }
 
-            var player = Player.m_localPlayer;
-            var inventory = player.GetInventory();
             foreach (var selectedItem in selectedItems)
             {
-                inventory.RemoveItem(selectedItem.Item1.GetItem(), selectedItem.Item2);
+                InventoryManagement.Instance.RemoveItem(selectedItem.Item1.GetItem().m_shared.m_name, selectedItem.Item2);
             }
 
             GiveItemsToPlayer(sacrificeProducts);

--- a/EpicLoot-UnityLib/src/UpgradeTableUI.cs
+++ b/EpicLoot-UnityLib/src/UpgradeTableUI.cs
@@ -212,8 +212,8 @@ namespace EpicLoot_UnityLib
             if (maxLevel)
                 return;
 
-            var cost = EnchantingTableUI.instance.SourceTable.IsFeatureLocked(feature) 
-                ? EnchantingTableUI.instance.SourceTable.GetFeatureUnlockCost(feature) 
+            var cost = EnchantingTableUI.instance.SourceTable.IsFeatureLocked(feature)
+                ? EnchantingTableUI.instance.SourceTable.GetFeatureUnlockCost(feature)
                 : EnchantingTableUI.instance.SourceTable.GetFeatureUpgradeCost(feature);
 
             var canAfford = LocalPlayerCanAffordCost(cost);
@@ -224,7 +224,8 @@ namespace EpicLoot_UnityLib
                 {
                     if (!success)
                     {
-                        Debug.LogError($"[Enchanting Upgrade] ERROR: Tried to upgrade ({feature}) to level ({currentLevel + 1}) but it failed!");
+                        Debug.LogError($"[Enchanting Upgrade] ERROR: " +
+                            $"Tried to upgrade ({feature}) to level ({currentLevel + 1}) but it failed!");
                         return;
                     }
 
@@ -233,15 +234,15 @@ namespace EpicLoot_UnityLib
                     {
                         if (!LocalPlayerCanAffordCost(cost))
                         {
-                            Debug.LogError("[Augment Item] ERROR: Tried to augment item but could not afford the cost. This should not happen!");
+                            Debug.LogError("[Augment Item] ERROR: Tried to augment item but could not afford the cost. " +
+                                "This should not happen!");
                             return;
                         }
 
-                        var inventory = player.GetInventory();
                         foreach (var costElement in cost)
                         {
                             var costItem = costElement.GetItem();
-                            inventory.RemoveItem(costItem.m_shared.m_name, costItem.m_stack);
+                            InventoryManagement.Instance.RemoveItem(costItem.m_shared.m_name, costItem.m_stack);
                         }
                     }
 

--- a/EpicLoot/CHANGELOG.md
+++ b/EpicLoot/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Version 0.10.2
+
+* Set fallback gambling Coins from 1 to 10000 when misconfigured.
+* Tweaked default fallback items for the item info configuration.
+* Set default maximum radius for Ashlands adventure spawns to 8000, should help with performance issues when spawning bounties and treasure chests.
+* Bounties and treasure chest should no longer spawn in lava.
+* Treasure chests now delete themselves (like tombstones) after fully looted.
+* Tweaked code for buying treasure chests to prevent accidental multiple purchase.
+* Added support for the nocost cheat for Epic Loot trader menu.
+* Epic Loot trader menu now allows you to buy items (and do other interactions) with a full inventory. Items will drop at the player's feet.
+* Reworked gating logic to fix bugs with some items dropping when not allowed.
+* Simplified double and triple shot checks to improve other mod compatibilities.
+* Reworked inventory management (checks, additions, removal) into a new class EpicLoot_UnityLib.InventoryManagement to improve other mod compatibilities.
+* Re-enabled gotomerchant command to teleport the player again.
+* Set the default value of the "Config Sync - Lock Config" configuration to true.
+
 ## Version 0.10.1
 
 * Fixed internal mod version and updated logo.

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -92,7 +92,7 @@ namespace EpicLoot
     {
         public const string PluginId = "randyknapp.mods.epicloot";
         public const string DisplayName = "Epic Loot";
-        public const string Version = "0.10.1";
+        public const string Version = "0.10.2";
 
         private readonly ConfigSync _configSync = new ConfigSync(PluginId) { DisplayName = DisplayName, CurrentVersion = Version, MinimumRequiredVersion = "0.9.35" };
 
@@ -300,7 +300,7 @@ namespace EpicLoot
                 "Set to false to disable. This will not actually remove active treasure maps or bounties from your save.");
             _andvaranautRange = SyncedConfig("Balance", "Andvaranaut Range", 20,
                 "Sets the range that Andvaranaut will locate a treasure chest.");
-            _serverConfigLocked = SyncedConfig("Config Sync", "Lock Config", false,
+            _serverConfigLocked = SyncedConfig("Config Sync", "Lock Config", true,
                 new ConfigDescription("[Server Only] The configuration is locked and may not be changed by clients " +
                 "once it has been synced from the server. Only valid for server config, will have no effect on clients."));
             SetItemDropChance = SyncedConfig("Balance", "Set Item Drop Chance", 0.15f,

--- a/EpicLoot/Properties/AssemblyInfo.cs
+++ b/EpicLoot/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.1")]
-[assembly: AssemblyFileVersion("0.10.1")]
+[assembly: AssemblyVersion("0.10.2")]
+[assembly: AssemblyFileVersion("0.10.2")]

--- a/EpicLoot/config/adventuredata.json
+++ b/EpicLoot/config/adventuredata.json
@@ -238,7 +238,7 @@
       { "Biome": "Mountain",    "Cost": 400, "ForestTokens": 20, "MinRadius": 2000, "MaxRadius": 6000 },
       { "Biome": "Plains",      "Cost": 500, "ForestTokens": 25, "MinRadius": 3000, "MaxRadius": 6000 },
       { "Biome": "Mistlands",   "Cost": 600, "ForestTokens": 30, "MinRadius": 5000, "MaxRadius": 9000 },
-      { "Biome": "AshLands",    "Cost": 700, "ForestTokens": 35, "MinRadius": 5000, "MaxRadius": 15000 }
+      { "Biome": "AshLands",    "Cost": 700, "ForestTokens": 35, "MinRadius": 8000, "MaxRadius": 15000 }
     ],
     "StartRadiusMin": 0,
     "StartRadiusMax": 500,

--- a/EpicLoot/config/iteminfo.json
+++ b/EpicLoot/config/iteminfo.json
@@ -13,7 +13,7 @@
   "ItemInfo": [
     {
       "Type": "Swords",
-      "Fallback": "AxeFlint",
+      "Fallback": "Axes",
       "Items": [ "SwordBronze", "SwordIron", "SwordSilver", "SwordBlackmetal", "SwordMistwalker", "THSwordKrom", "SwordNiedhogg", "THSwordSlayer", "SwordDyrnwyn" ],
       "ItemsByBoss" : {
         "defeated_eikthyr"    : [],
@@ -27,7 +27,7 @@
     },
     {
       "Type": "Axes",
-      "Fallback": "Club",
+      "Fallback": "AxeStone",
       "Items": [ "AxeStone", "AxeFlint", "AxeBronze", "AxeIron", "AxeBlackMetal", "AxeJotunBane", "AxeBerzerkr"],
       "ItemsByBoss" : {
         "defeated_eikthyr"    : [ "AxeStone", "AxeFlint" ],
@@ -40,22 +40,22 @@
       }
     },
     {
-        "Type": "TwoHandAxes",
-        "Fallback": "Axes",
-        "Items": [ "Battleaxe", "BattleaxeCrystal" ],
-        "ItemsByBoss": {
-            "defeated_eikthyr"    : [],
-            "defeated_gdking"     : [],
-            "defeated_bonemass"   : [ "Battleaxe" ],
-            "defeated_dragon"     : [ "BattleaxeCrystal" ],
-            "defeated_goblinking" : [],
-            "defeated_queen"      : [],
-            "defeated_fader"      : []
-        }
+      "Type": "TwoHandAxes",
+      "Fallback": "Axes",
+      "Items": [ "Battleaxe", "BattleaxeCrystal" ],
+      "ItemsByBoss": {
+        "defeated_eikthyr"    : [],
+        "defeated_gdking"     : [],
+        "defeated_bonemass"   : [ "Battleaxe" ],
+        "defeated_dragon"     : [ "BattleaxeCrystal" ],
+        "defeated_goblinking" : [],
+        "defeated_queen"      : [],
+        "defeated_fader"      : []
+      }
     },
     {
       "Type": "Knives",
-      "Fallback": "Clubs",
+      "Fallback": "Axes",
       "Items": [ "KnifeFlint", "KnifeCopper", "KnifeChitin", "KnifeSilver", "KnifeBlackMetal", "KnifeSkollAndHati" ],
       "ItemsByBoss" : {
         "defeated_eikthyr"    : [ "KnifeFlint" ],
@@ -82,24 +82,24 @@
       }
     },
     {
-        "Type": "Staffs",
-        "Fallback": "Spears",
-        "Items": [ "StaffFireball", "StaffIceShards", "StaffShield", "StaffSkeleton", "StaffClusterbomb", "StaffLightning", "StaffRedTroll", "StaffGreenRoots" ],
-        "ItemsByBoss": {
-            "defeated_eikthyr"    : [],
-            "defeated_gdking"     : [],
-            "defeated_bonemass"   : [],
-            "defeated_dragon"     : [],
-            "defeated_goblinking" : [],
-            "defeated_queen"      : [ "StaffFireball", "StaffIceShards", "StaffShield", "StaffSkeleton" ],
-            "defeated_fader"      : [ "StaffClusterbomb", "StaffLightning", "StaffRedTroll", "StaffGreenRoots" ]
-        }
+      "Type": "Staffs",
+      "Fallback": "Spears",
+      "Items": [ "StaffFireball", "StaffIceShards", "StaffShield", "StaffSkeleton", "StaffClusterbomb", "StaffLightning", "StaffRedTroll", "StaffGreenRoots" ],
+      "ItemsByBoss": {
+        "defeated_eikthyr"    : [],
+        "defeated_gdking"     : [],
+        "defeated_bonemass"   : [],
+        "defeated_dragon"     : [],
+        "defeated_goblinking" : [],
+        "defeated_queen"      : [ "StaffFireball", "StaffIceShards", "StaffShield", "StaffSkeleton" ],
+        "defeated_fader"      : [ "StaffClusterbomb", "StaffLightning", "StaffRedTroll", "StaffGreenRoots" ]
+      }
     },
     {
       "Type": "Clubs",
-      "Fallback": "",
+      "Fallback": "Club",
       "Items": [ "Club", "MaceBronze", "MaceIron", "MaceSilver", "MaceNeedle", "MaceEldner" ],
-      "ItemsByBoss" : {
+      "ItemsByBoss": {
         "defeated_eikthyr"    : [ "Club" ],
         "defeated_gdking"     : [ "MaceBronze" ],
         "defeated_bonemass"   : [ "MaceIron" ],
@@ -110,60 +110,60 @@
       }
     },
     {
-        "Type": "Sledges",
-        "Fallback": "Clubs",
-        "Items": [ "SledgeStagbreaker", "SledgeIron", "SledgeDemolisher" ],
-        "ItemsByBoss": {
-            "defeated_eikthyr"    : [ "SledgeStagbreaker" ],
-            "defeated_gdking"     : [],
-            "defeated_bonemass"   : [ "SledgeIron" ],
-            "defeated_dragon"     : [],
-            "defeated_goblinking" : [],
-            "defeated_queen"      : [ "SledgeDemolisher" ],
-            "defeated_fader"      : []
-        }
+      "Type": "Sledges",
+      "Fallback": "Clubs",
+      "Items": [ "SledgeStagbreaker", "SledgeIron", "SledgeDemolisher" ],
+      "ItemsByBoss": {
+        "defeated_eikthyr"    : [ "SledgeStagbreaker" ],
+        "defeated_gdking"     : [],
+        "defeated_bonemass"   : [ "SledgeIron" ],
+        "defeated_dragon"     : [],
+        "defeated_goblinking" : [],
+        "defeated_queen"      : [ "SledgeDemolisher" ],
+        "defeated_fader"      : []
+      }
     },
     {
-        "Type": "Polearms",
-        "Fallback": "Spears",
-        "Items": [ "AtgeirBronze", "AtgeirIron", "AtgeirBlackmetal", "AtgeirHimminAfl" ],
-        "ItemsByBoss": {
-            "defeated_eikthyr"    : [],
-            "defeated_gdking"     : [ "AtgeirBronze" ],
-            "defeated_bonemass"   : [ "AtgeirIron" ],
-            "defeated_dragon"     : [],
-            "defeated_goblinking" : [ "AtgeirBlackmetal" ],
-            "defeated_queen"      : [ "AtgeirHimminAfl" ],
-            "defeated_fader"      : []
-        }
+      "Type": "Polearms",
+      "Fallback": "Spears",
+      "Items": [ "AtgeirBronze", "AtgeirIron", "AtgeirBlackmetal", "AtgeirHimminAfl" ],
+      "ItemsByBoss": {
+        "defeated_eikthyr"    : [],
+        "defeated_gdking"     : [ "AtgeirBronze" ],
+        "defeated_bonemass"   : [ "AtgeirIron" ],
+        "defeated_dragon"     : [],
+        "defeated_goblinking" : [ "AtgeirBlackmetal" ],
+        "defeated_queen"      : [ "AtgeirHimminAfl" ],
+        "defeated_fader"      : []
+      }
     },
     {
-        "Type": "Spears",
-        "Fallback": "Axes",
-        "Items": [ "SpearFlint", "SpearBronze", "SpearElderbark", "SpearChitin", "SpearWolfFang", "SpearCarapace", "SpearSplitner" ],
-        "ItemsByBoss": {
-            "defeated_eikthyr"    : [ "SpearFlint" ],
-            "defeated_gdking"     : [ "SpearBronze" ],
-            "defeated_bonemass"   : [ "SpearElderbark", "SpearChitin" ],
-            "defeated_dragon"     : [ "SpearWolfFang" ],
-            "defeated_goblinking" : [],
-            "defeated_queen"      : [ "SpearCarapace" ],
-            "defeated_fader"      : [ "SpearSplitner" ]
-        }
+      "Type": "Spears",
+      "Fallback": "Axes",
+      "Items": [ "SpearFlint", "SpearBronze", "SpearElderbark", "SpearChitin", "SpearWolfFang", "SpearCarapace", "SpearSplitner" ],
+      "ItemsByBoss": {
+        "defeated_eikthyr"    : [ "SpearFlint" ],
+        "defeated_gdking"     : [ "SpearBronze" ],
+        "defeated_bonemass"   : [ "SpearElderbark", "SpearChitin" ],
+        "defeated_dragon"     : [ "SpearWolfFang" ],
+        "defeated_goblinking" : [],
+        "defeated_queen"      : [ "SpearCarapace" ],
+        "defeated_fader"      : [ "SpearSplitner" ]
+      }
     },
     {
-        "Type": "Pickaxes",
-        "Fallback": "Axes",
-        "Items": [ "PickaxeAntler", "PickaxeBronze", "PickaxeIron", "PickaxeBlackMetal" ],
-        "ItemsByBoss": {
-            "defeated_eikthyr"    : [ "PickaxeAntler" ],
-            "defeated_gdking"     : [ "PickaxeBronze" ],
-            "defeated_bonemass"   : [ "PickaxeIron" ],
-            "defeated_dragon"     : [],
-            "defeated_goblinking" : [ "PickaxeBlackMetal" ],
-            "defeated_queen"      : [],
-            "defeated_fader"      : []
-        }
+      "Type": "Pickaxes",
+      "Fallback": "Axes",
+      "Items": [ "PickaxeAntler", "PickaxeBronze", "PickaxeIron", "PickaxeBlackMetal" ],
+      "ItemsByBoss": {
+        "defeated_eikthyr"    : [ "PickaxeAntler" ],
+        "defeated_gdking"     : [ "PickaxeBronze" ],
+        "defeated_bonemass"   : [ "PickaxeIron" ],
+        "defeated_dragon"     : [],
+        "defeated_goblinking" : [ "PickaxeBlackMetal" ],
+        "defeated_queen"      : [],
+        "defeated_fader"      : []
+      }
     },
     {
       "Type": "Bows",
@@ -180,18 +180,18 @@
       }
     },
     {
-        "Type": "Bucklers",
-        "Fallback": "RoundShields",
-        "Items": [ "ShieldBronzeBuckler", "ShieldIronBuckler", "ShieldCarapaceBuckler" ],
-        "ItemsByBoss": {
-            "defeated_eikthyr"    : [],
-            "defeated_gdking"     : [ "ShieldBronzeBuckler" ],
-            "defeated_bonemass"   : [ "ShieldIronBuckler" ],
-            "defeated_dragon"     : [],
-            "defeated_goblinking" : [],
-            "defeated_queen"      : [ "ShieldCarapaceBuckler" ],
-            "defeated_fader"      : []
-        }
+      "Type": "Bucklers",
+      "Fallback": "RoundShields",
+      "Items": [ "ShieldBronzeBuckler", "ShieldIronBuckler", "ShieldCarapaceBuckler" ],
+      "ItemsByBoss": {
+        "defeated_eikthyr"    : [],
+        "defeated_gdking"     : [ "ShieldBronzeBuckler" ],
+        "defeated_bonemass"   : [ "ShieldIronBuckler" ],
+        "defeated_dragon"     : [],
+        "defeated_goblinking" : [],
+        "defeated_queen"      : [ "ShieldCarapaceBuckler" ],
+        "defeated_fader"      : []
+      }
     },
     {
       "Type": "RoundShields",
@@ -223,7 +223,7 @@
     },
     {
       "Type": "ChestArmor",
-      "Fallback": "",
+      "Fallback": "ArmorRagsChest",
       "Items": [ "ArmorRagsChest", "ArmorLeatherChest", "ArmorBronzeChest", "ArmorTrollLeatherChest", "ArmorIronChest", "ArmorRootChest", "ArmorWolfChest", "ArmorFenringChest", "ArmorPaddedCuirass", "ArmorCarapaceChest", "ArmorMageChest", "ArmorFlametalChest", "ArmorAshlandsMediumChest", "ArmorMageChest_Ashlands" ],
       "ItemsByBoss" : {
         "defeated_eikthyr"    : [ "ArmorRagsChest", "ArmorLeatherChest" ],
@@ -237,7 +237,7 @@
     },
     {
       "Type": "LegsArmor",
-      "Fallback": "",
+      "Fallback": "ArmorRagsLegs",
       "Items": [ "ArmorRagsLegs", "ArmorLeatherLegs", "ArmorTrollLeatherLegs", "ArmorBronzeLegs", "ArmorIronLegs", "ArmorRootLegs", "ArmorWolfLegs", "ArmorFenringLegs", "ArmorPaddedGreaves", "ArmorCarapaceLegs", "ArmorMageLegs", "ArmorFlametalLegs", "ArmorAshlandsMediumlegs", "ArmorMageLegs_Ashlands" ],
       "ItemsByBoss" : {
         "defeated_eikthyr"    : [ "ArmorRagsLegs", "ArmorLeatherLegs" ],
@@ -279,7 +279,7 @@
     },
     {
       "Type": "Torches",
-      "Fallback": "Club",
+      "Fallback": "Clubs",
       "Items": [ "Torch" ],
       "ItemsByBoss" : {
         "defeated_eikthyr"    : [ "Torch" ],

--- a/EpicLoot/src/Adventure/AdventureDataManager.cs
+++ b/EpicLoot/src/Adventure/AdventureDataManager.cs
@@ -81,7 +81,9 @@ namespace EpicLoot.Adventure
 
         public static string GetBountyName(BountyInfo bountyInfo)
         {
-            return Localization.instance.Localize(string.IsNullOrEmpty(bountyInfo.TargetName) ? GetMonsterName(bountyInfo.Target.MonsterID) : bountyInfo.TargetName);
+            return Localization.instance.Localize(string.IsNullOrEmpty(bountyInfo.TargetName) ?
+                GetMonsterName(bountyInfo.Target.MonsterID) :
+                bountyInfo.TargetName);
         }
 
         public static string GetMonsterName(string monsterID)

--- a/EpicLoot/src/Adventure/BuyListElement.cs
+++ b/EpicLoot/src/Adventure/BuyListElement.cs
@@ -49,10 +49,11 @@ namespace EpicLoot.Adventure
 
         public bool CanAfford(Currencies currencies)
         {
-            return ItemInfo.Cost.Coins <= currencies.Coins
+            return (ItemInfo.Cost.Coins <= currencies.Coins
                    && ItemInfo.Cost.ForestTokens <= currencies.ForestTokens
                    && ItemInfo.Cost.IronBountyTokens <= currencies.IronBountyTokens
-                   && ItemInfo.Cost.GoldBountyTokens <= currencies.GoldBountyTokens;
+                   && ItemInfo.Cost.GoldBountyTokens <= currencies.GoldBountyTokens)
+                   || Player.m_localPlayer.NoCostCheat();
         }
 
         public void SetItem(SecretStashItemInfo itemInfo, Currencies currencies)

--- a/EpicLoot/src/Adventure/MerchantPanel.cs
+++ b/EpicLoot/src/Adventure/MerchantPanel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using EpicLoot.Adventure.Feature;
 using EpicLoot.Crafting;
+using EpicLoot_UnityLib;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -268,8 +269,7 @@ namespace EpicLoot.Adventure
                 ZNetScene.instance.Destroy(itemDrop.gameObject);
             }
 
-            var inventory = player.GetInventory();
-            if (item == null || !inventory.AddItem(item))
+            if (item == null || !InventoryManagement.Instance.GiveItem(item))
             {
                 EpicLoot.LogWarning($"Could not buy item {listItem.ItemInfo.Item.m_shared.m_name}");
                 return;
@@ -282,29 +282,26 @@ namespace EpicLoot.Adventure
 
             if (listItem.ItemInfo.Cost.Coins > 0)
             {
-                inventory.RemoveItem(GetCoinsName(), listItem.ItemInfo.Cost.Coins);
+                InventoryManagement.Instance.RemoveItem(GetCoinsName(), listItem.ItemInfo.Cost.Coins);
             }
 
             if (listItem.ItemInfo.Cost.ForestTokens > 0)
             {
-                inventory.RemoveItem(GetForestTokenName(), listItem.ItemInfo.Cost.ForestTokens);
+                InventoryManagement.Instance.RemoveItem(GetForestTokenName(), listItem.ItemInfo.Cost.ForestTokens);
             }
 
             if (listItem.ItemInfo.Cost.IronBountyTokens > 0)
             {
-                inventory.RemoveItem(GetIronBountyTokenName(), listItem.ItemInfo.Cost.IronBountyTokens);
+                InventoryManagement.Instance.RemoveItem(GetIronBountyTokenName(), listItem.ItemInfo.Cost.IronBountyTokens);
             }
 
             if (listItem.ItemInfo.Cost.GoldBountyTokens > 0)
             {
-                inventory.RemoveItem(GetGoldBountyTokenName(), listItem.ItemInfo.Cost.GoldBountyTokens);
+                InventoryManagement.Instance.RemoveItem(GetGoldBountyTokenName(), listItem.ItemInfo.Cost.GoldBountyTokens);
             }
 
             StoreGui.instance.m_trader.OnBought(null);
             StoreGui.instance.m_buyEffects.Create(player.transform.position, Quaternion.identity);
-            Player.m_localPlayer.ShowPickupMessage(listItem.ItemInfo.Item, listItem.ItemInfo.Item.m_stack);
-
-            //Gogan.LogEvent("Game", "BoughtItem", selectedStashItem.Item, 0L);
         }
 
         private static string GetRefreshTimeTooltip(int refreshInterval)
@@ -358,11 +355,9 @@ namespace EpicLoot.Adventure
 
         private bool UpdateCurrencies()
         {
-            var player = Player.m_localPlayer;
-            var inventory = player.GetInventory();
             var currenciesChanged = false;
 
-            var newCoinCount = inventory.CountItems(GetCoinsName());
+            var newCoinCount = InventoryManagement.Instance.CountItem(GetCoinsName());
             if (_currencies.Coins != newCoinCount)
             {
                 _currencies.Coins = newCoinCount;
@@ -370,7 +365,7 @@ namespace EpicLoot.Adventure
                 currenciesChanged = true;
             }
 
-            var newForestTokenCount = inventory.CountItems(GetForestTokenName());
+            var newForestTokenCount = InventoryManagement.Instance.CountItem(GetForestTokenName());
             if (_currencies.ForestTokens != newForestTokenCount)
             {
                 _currencies.ForestTokens = newForestTokenCount;
@@ -378,7 +373,7 @@ namespace EpicLoot.Adventure
                 currenciesChanged = true;
             }
 
-            var newIronBountyTokenCount = inventory.CountItems(GetIronBountyTokenName());
+            var newIronBountyTokenCount = InventoryManagement.Instance.CountItem(GetIronBountyTokenName());
             if (newIronBountyTokenCount != _currencies.IronBountyTokens)
             {
                 _currencies.IronBountyTokens = newIronBountyTokenCount;
@@ -386,7 +381,7 @@ namespace EpicLoot.Adventure
                 currenciesChanged = true;
             }
 
-            var newGoldBountyTokenCount = inventory.CountItems(GetGoldBountyTokenName());
+            var newGoldBountyTokenCount = InventoryManagement.Instance.CountItem(GetGoldBountyTokenName());
             if (newGoldBountyTokenCount != _currencies.GoldBountyTokens)
             {
                 _currencies.GoldBountyTokens = newGoldBountyTokenCount;

--- a/EpicLoot/src/Adventure/MinimapController.cs
+++ b/EpicLoot/src/Adventure/MinimapController.cs
@@ -156,7 +156,6 @@ namespace EpicLoot.Adventure
             AreaPinInfo newPin = null;
             switch (pinJob.Task)
             {
-                    
                 case MinimapPinQueueTask.AddBountyPin:
                     newPin = pinJob.BountyPin.Value;
                     break;
@@ -177,7 +176,8 @@ namespace EpicLoot.Adventure
             //Add Debug Pin
             if (pinJob.DebugMode)
             {
-                newPin.DebugPin = _minimap.AddPin(newPin.Position, Minimap.PinType.Icon3, $"{newPin.Position.x:0.0}, {newPin.Position.z:0.0}", false, false);
+                newPin.DebugPin = _minimap.AddPin(newPin.Position, Minimap.PinType.Icon3,
+                    $"{newPin.Position.x:0.0}, {newPin.Position.z:0.0}", false, false);
             }
             
             switch (pinJob.Task)
@@ -212,7 +212,8 @@ namespace EpicLoot.Adventure
                 return;
 
             var unfoundTreasureChests = adventureSaveData.GetUnfoundTreasureChests();
-            var oldPins = TreasureMapPins.Where(pinEntry => !unfoundTreasureChests.Exists(x => x.Interval == pinEntry.Key.Item1 && x.Biome == pinEntry.Key.Item2)).ToList();
+            var oldPins = TreasureMapPins.Where(pinEntry => !unfoundTreasureChests
+                .Exists(x => x.Interval == pinEntry.Key.Item1 && x.Biome == pinEntry.Key.Item2)).ToList();
             foreach (var pinEntry in oldPins)
             {
                 var pinJob = new PinJob
@@ -234,7 +235,9 @@ namespace EpicLoot.Adventure
                     {
                         Position = chestInfo.Position + chestInfo.MinimapCircleOffset,
                         Type = EpicLoot.TreasureMapPinType,
-                        Name = Localization.instance.Localize("$mod_epicloot_treasurechest_minimappin", Localization.instance.Localize($"$biome_{chestInfo.Biome.ToString().ToLowerInvariant()}"), (chestInfo.Interval + 1).ToString())
+                        Name = Localization.instance.Localize("$mod_epicloot_treasurechest_minimappin",
+                            Localization.instance.Localize($"$biome_{chestInfo.Biome.ToString().ToLowerInvariant()}"),
+                            (chestInfo.Interval + 1).ToString())
                     };
 
                     var pinJob = new PinJob

--- a/EpicLoot/src/Adventure/TreasureMapChest.cs
+++ b/EpicLoot/src/Adventure/TreasureMapChest.cs
@@ -20,6 +20,7 @@ namespace EpicLoot.Adventure
             if (container == null || container.m_nview == null)
             {
                 EpicLoot.LogError($"Trying to set up TreasureMapChest ({biome} {treasureMapInterval}) but there was no Container component!");
+                return;
             }
 
             var zdo = container.m_nview.GetZDO();
@@ -64,21 +65,11 @@ namespace EpicLoot.Adventure
             var container = GetComponent<Container>();
             if (container != null)
             {
-                if (hasBeenFound && container.m_inventory.NrOfItems() == 0)
-                {
-                    // Remove treasure chests that have already been found
-                    var zdo = container.m_nview.GetZDO();
-                    if (zdo != null && zdo.IsValid())
-                    {
-                        zdo.SetOwner(ZDOMan.GetSessionID());
-                        container.m_nview.Destroy();
-                        return;
-                    }
-                }
-
-                var label = Localization.instance.Localize("$mod_epicloot_treasurechest_name", $"$biome_{Biome.ToString().ToLower()}", (treasureMapInterval + 1).ToString());
+                var label = Localization.instance.Localize("$mod_epicloot_treasurechest_name",
+                    $"$biome_{Biome.ToString().ToLower()}", (treasureMapInterval + 1).ToString());
                 container.m_name = Localization.instance.Localize(label);
                 container.m_privacy = hasBeenFound ? Container.PrivacySetting.Public : Container.PrivacySetting.Private;
+                container.m_autoDestroyEmpty = true;
             }
 
             var piece = GetComponent<Piece>();

--- a/EpicLoot/src/Adventure/TreasureMapListElement.cs
+++ b/EpicLoot/src/Adventure/TreasureMapListElement.cs
@@ -47,7 +47,7 @@ namespace EpicLoot.Adventure
         public void SetItem(TreasureMapItemInfo itemInfo, int currentCoins)
         {
             ItemInfo = itemInfo;
-            CanAfford = Price <= currentCoins;
+            CanAfford = Price <= currentCoins || Player.m_localPlayer.NoCostCheat();
             AlreadyPurchased = itemInfo.AlreadyPurchased;
 
             var displayName = Localization.instance.Localize("$mod_epicloot_treasuremap_name", $"$biome_{Biome.ToString().ToLower()}", (itemInfo.Interval + 1).ToString());

--- a/EpicLoot/src/Adventure/feature/Bounties.cs
+++ b/EpicLoot/src/Adventure/feature/Bounties.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using BepInEx;
 using Common;
+using EpicLoot_UnityLib;
 using HarmonyLib;
 using Newtonsoft.Json;
 using UnityEngine;
@@ -339,18 +340,17 @@ namespace EpicLoot.Adventure.Feature
 
             MessageHud.instance.ShowBiomeFoundMsg("$mod_epicloot_bounties_claimedmsg", true);
 
-            var inventory = player.GetInventory();
             if (bountyInfo.RewardIron > 0)
             {
-                inventory.AddItem("IronBountyToken", bountyInfo.RewardIron, 1, 0, 0, string.Empty);
+                InventoryManagement.Instance.GiveItem("IronBountyToken", bountyInfo.RewardIron);
             }
             if (bountyInfo.RewardGold > 0)
             {
-                inventory.AddItem("GoldBountyToken", bountyInfo.RewardGold, 1, 0, 0, string.Empty);
+                InventoryManagement.Instance.GiveItem("GoldBountyToken", bountyInfo.RewardGold);
             }
             if (bountyInfo.RewardCoins > 0)
             {
-                inventory.AddItem("Coins", bountyInfo.RewardCoins, 1, 0, 0, string.Empty);
+                InventoryManagement.Instance.GiveItem("Coins", bountyInfo.RewardCoins);
             }
         }
 

--- a/EpicLoot/src/Adventure/feature/BountiesListPanel.cs
+++ b/EpicLoot/src/Adventure/feature/BountiesListPanel.cs
@@ -118,8 +118,7 @@ namespace EpicLoot.Adventure.Feature
         public override void RefreshButton(Currencies playerCurrencies)
         {
             var selectedItem = GetSelectedItem();
-            var haveSpace = CanAddRewardToInventory(selectedItem);
-            MainButton.interactable = selectedItem != null && selectedItem.CanClaim && haveSpace;
+            MainButton.interactable = selectedItem != null && selectedItem.CanClaim;
             var tooltip = MainButton.GetComponent<UITooltip>();
             if (tooltip != null)
             {
@@ -128,59 +127,11 @@ namespace EpicLoot.Adventure.Feature
                 {
                     tooltip.m_text = "$mod_epicloot_bounties_notcompletetooltip";
                 }
-                else if (selectedItem != null && !haveSpace)
-                {
-                    tooltip.m_text = "$mod_epicloot_bounties_noroomtooltip";
-                }
             }
 
             var canAbandon = selectedItem != null && selectedItem.BountyInfo.State == BountyState.InProgress;
             AbandonButton.interactable = canAbandon;
             AbandonButtonIcon.color = canAbandon ? Color.red : Color.grey;
-        }
-
-        public bool CanAddRewardToInventory(BountyListElement selectedItem)
-        {
-            if (selectedItem == null)
-            {
-                return false;
-            }
-
-            var rewardCount = (selectedItem.BountyInfo.RewardIron > 0 ? 1 : 0) + (selectedItem.BountyInfo.RewardGold > 0 ? 1 : 0) + (selectedItem.BountyInfo.RewardCoins > 0 ? 1 : 0);
-            var hasEmptySlots = Player.m_localPlayer.GetInventory().GetEmptySlots() >= rewardCount;
-            if (hasEmptySlots)
-            {
-                return true;
-            }
-
-            if (selectedItem.BountyInfo.RewardIron > 0)
-            {
-                var haveSpace = Player.m_localPlayer.GetInventory().FindFreeStackSpace(MerchantPanel.GetIronBountyTokenName(), Game.m_worldLevel) > selectedItem.BountyInfo.RewardIron;
-                if (!haveSpace)
-                {
-                    return false;
-                }
-            }
-
-            if (selectedItem.BountyInfo.RewardGold > 0)
-            {
-                var haveSpace = Player.m_localPlayer.GetInventory().FindFreeStackSpace(MerchantPanel.GetGoldBountyTokenName(), Game.m_worldLevel) > selectedItem.BountyInfo.RewardGold;
-                if (!haveSpace)
-                {
-                    return false;
-                }
-            }
-
-            if (selectedItem.BountyInfo.RewardCoins > 0)
-            {
-                var haveSpace = Player.m_localPlayer.GetInventory().FindFreeStackSpace(MerchantPanel.GetCoinsName(), Game.m_worldLevel) > selectedItem.BountyInfo.RewardCoins;
-                if (!haveSpace)
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         protected override void OnMainButtonClicked()

--- a/EpicLoot/src/Adventure/feature/Gamble.cs
+++ b/EpicLoot/src/Adventure/feature/Gamble.cs
@@ -21,12 +21,11 @@ namespace EpicLoot.Adventure.Feature
             var random = GetRandom();
             var results = new List<SecretStashItemInfo>();
 
-            var availableGambles = GetAvailableGambles();
-            RollOnListNTimes(random, availableGambles.ToList(), AdventureDataManager.Config.Gamble.GamblesCount, results);
+            List<SecretStashItemInfo> availableGambles = GetAvailableGambles();
+            RollOnListNTimes(random, availableGambles, AdventureDataManager.Config.Gamble.GamblesCount, results);
 
-            availableGambles = GetAvailableGambles();
             var forestTokenGambles = new List<SecretStashItemInfo>();
-            RollOnListNTimes(random, availableGambles.ToList(), AdventureDataManager.Config.Gamble.ForestTokenGamblesCount, forestTokenGambles);
+            RollOnListNTimes(random, availableGambles, AdventureDataManager.Config.Gamble.ForestTokenGamblesCount, forestTokenGambles);
             foreach (var forestTokenGamble in forestTokenGambles)
             {
                 forestTokenGamble.Cost.Coins = (int)(forestTokenGamble.Cost.Coins * AdventureDataManager.Config.Gamble.ForestTokenGambleCoinsCost);
@@ -36,9 +35,8 @@ namespace EpicLoot.Adventure.Feature
                 results.Add(forestTokenGamble);
             }
 
-            availableGambles = GetAvailableGambles();
             var ironBountyGambles = new List<SecretStashItemInfo>();
-            RollOnListNTimes(random, availableGambles.ToList(), AdventureDataManager.Config.Gamble.IronBountyGamblesCount, ironBountyGambles);
+            RollOnListNTimes(random, availableGambles, AdventureDataManager.Config.Gamble.IronBountyGamblesCount, ironBountyGambles);
             foreach (var ironBountyGamble in ironBountyGambles)
             {
                 ironBountyGamble.Cost.Coins = (int)(ironBountyGamble.Cost.Coins * AdventureDataManager.Config.Gamble.IronBountyGambleCoinsCost);
@@ -48,9 +46,8 @@ namespace EpicLoot.Adventure.Feature
                 results.Add(ironBountyGamble);
             }
 
-            availableGambles = GetAvailableGambles();
             var goldBountyGambles = new List<SecretStashItemInfo>();
-            RollOnListNTimes(random, availableGambles.ToList(), AdventureDataManager.Config.Gamble.GoldBountyGamblesCount, goldBountyGambles);
+            RollOnListNTimes(random, availableGambles, AdventureDataManager.Config.Gamble.GoldBountyGamblesCount, goldBountyGambles);
             foreach (var goldBountyGamble in goldBountyGambles)
             {
                 goldBountyGamble.Cost.Coins = (int)(goldBountyGamble.Cost.Coins * AdventureDataManager.Config.Gamble.GoldBountyGambleCoinsCost);
@@ -73,13 +70,14 @@ namespace EpicLoot.Adventure.Feature
                     EpicLoot.LogWarning($"Found empty itemConfig.. skipping.");
                     continue;
                 }
+
                 var gatingMode = EpicLoot.GetGatedItemTypeMode();
                 if (gatingMode == GatedItemTypeMode.Unlimited)
                 {
                     gatingMode = GatedItemTypeMode.PlayerMustKnowRecipe;
                 }
 
-                var itemId = GatedItemTypeHelper.GetItemFromCategory(itemConfig, gatingMode);
+                var itemId = GatedItemTypeHelper.GetItemFromCategory(itemConfig, gatingMode, 0);
                 if (string.IsNullOrEmpty(itemId))
                 {
                     EpicLoot.LogWarning($"[AdventureData] Could not find item id from Category (orig={itemConfig})!");
@@ -106,7 +104,7 @@ namespace EpicLoot.Adventure.Feature
             var costConfig = AdventureDataManager.Config.Gamble.GambleCosts.Find(x => x.Item == itemId);
             return new Currencies()
             {
-                Coins = costConfig?.CoinsCost ?? 1,
+                Coins = costConfig?.CoinsCost ?? 10000,
                 ForestTokens = costConfig?.ForestTokenCost ?? 0,
                 IronBountyTokens = costConfig?.IronBountyTokenCost ?? 0,
                 GoldBountyTokens = costConfig?.GoldBountyTokenCost ?? 0

--- a/EpicLoot/src/Adventure/feature/GambleListPanel.cs
+++ b/EpicLoot/src/Adventure/feature/GambleListPanel.cs
@@ -26,8 +26,7 @@ namespace EpicLoot.Adventure.Feature
         public override void RefreshButton(Currencies playerCurrencies)
         {
             var selectedItem = GetSelectedItem();
-            var haveSpace = Player.m_localPlayer.GetInventory().FindEmptySlot(false).x >= 0 || Player.m_localPlayer.GetInventory().FindFreeStackSpace(selectedItem?.ItemInfo.Item.m_shared.m_name, Game.m_worldLevel) > 0;
-            MainButton.interactable = selectedItem != null && selectedItem.CanAfford(playerCurrencies) && haveSpace;
+            MainButton.interactable = selectedItem != null && selectedItem.CanAfford(playerCurrencies);
             var tooltip = MainButton.GetComponent<UITooltip>();
             if (tooltip != null)
             {
@@ -35,10 +34,6 @@ namespace EpicLoot.Adventure.Feature
                 if (selectedItem != null && !selectedItem.CanAfford(playerCurrencies))
                 {
                     tooltip.m_text = "$mod_epicloot_merchant_cannotafford";
-                }
-                else if (!haveSpace)
-                {
-                    tooltip.m_text = "$mod_epicloot_merchant_noroomtooltip";
                 }
             }
         }

--- a/EpicLoot/src/Adventure/feature/SecretStashListPanel.cs
+++ b/EpicLoot/src/Adventure/feature/SecretStashListPanel.cs
@@ -27,8 +27,7 @@ namespace EpicLoot.Adventure.Feature
         public override void RefreshButton(Currencies playerCurrencies)
         {
             var selectedItem = GetSelectedItem();
-            var haveSpace = Player.m_localPlayer.GetInventory().FindEmptySlot(false).x >= 0 || Player.m_localPlayer.GetInventory().FindFreeStackSpace(selectedItem?.ItemInfo.Item.m_shared.m_name, default) > 0;
-            MainButton.interactable = selectedItem != null && selectedItem.CanAfford(playerCurrencies) && haveSpace;
+            MainButton.interactable = selectedItem != null && selectedItem.CanAfford(playerCurrencies);
             var tooltip = MainButton.GetComponent<UITooltip>();
             if (tooltip != null)
             {
@@ -36,10 +35,6 @@ namespace EpicLoot.Adventure.Feature
                 if (selectedItem != null && !selectedItem.CanAfford(playerCurrencies))
                 {
                     tooltip.m_text = "$mod_epicloot_merchant_cannotafford";
-                }
-                else if (!haveSpace)
-                {
-                    tooltip.m_text = "$mod_epicloot_merchant_noroomtooltip";
                 }
             }
         }

--- a/EpicLoot/src/Adventure/feature/TreasureMapListPanel.cs
+++ b/EpicLoot/src/Adventure/feature/TreasureMapListPanel.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using EpicLoot_UnityLib;
+using System.Collections;
+using UnityEngine;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
@@ -7,6 +9,7 @@ namespace EpicLoot.Adventure.Feature
     class TreasureMapListPanel : MerchantListPanel<TreasureMapListElement>
     {
         private readonly MerchantPanel _merchantPanel;
+        private IEnumerator SpawnTreasureChestCoroutine;
 
         public TreasureMapListPanel(MerchantPanel merchantPanel, TreasureMapListElement elementPrefab) 
             : base(
@@ -45,6 +48,11 @@ namespace EpicLoot.Adventure.Feature
 
         protected override void OnMainButtonClicked()
         {
+            if (SpawnTreasureChestCoroutine != null)
+            {
+                return;
+            }
+
             var player = Player.m_localPlayer;
             if (player == null)
             {
@@ -54,18 +62,27 @@ namespace EpicLoot.Adventure.Feature
             var treasureMap = GetSelectedItem();
             if (treasureMap != null)
             {
-                player.StartCoroutine(AdventureDataManager.TreasureMaps.SpawnTreasureChest(treasureMap.Biome, player, (success, position) =>
-                {
-                    if (success)
-                    {
-                        var inventory = player.GetInventory();
-                        inventory.RemoveItem(MerchantPanel.GetCoinsName(), treasureMap.Price);
-
-                        StoreGui.instance.m_trader.OnBought(null);
-                        StoreGui.instance.m_buyEffects.Create(player.transform.position, Quaternion.identity);
-                    }
-                }));
+                SpawnTreasureChestCoroutine = AdventureDataManager.TreasureMaps
+                    .SpawnTreasureChest(treasureMap.Biome, player, treasureMap.Price, OnSpawnTreasureChest);
+                player.StartCoroutine(SpawnTreasureChestCoroutine);
             }
+        }
+
+        private void OnSpawnTreasureChest(int price, bool success, Vector3 position)
+        {
+            if (success)
+            {
+                InventoryManagement.Instance.RemoveItem(MerchantPanel.GetCoinsName(), price);
+                
+                if (StoreGui.instance.m_trader != null)
+                {
+                    StoreGui.instance.m_trader.OnBought(null);
+                }
+
+                StoreGui.instance.m_buyEffects?.Create(Player.m_localPlayer.transform.position, Quaternion.identity);
+            }
+
+            SpawnTreasureChestCoroutine = null;
         }
 
         public override void RefreshItems(Currencies currencies)
@@ -89,7 +106,6 @@ namespace EpicLoot.Adventure.Feature
         public override void UpdateRefreshTime()
         {
             UpdateRefreshTime(AdventureDataManager.TreasureMaps.GetSecondsUntilRefresh());
-
         }
     }
 }

--- a/EpicLoot/src/Adventure/feature/TreasureMaps.cs
+++ b/EpicLoot/src/Adventure/feature/TreasureMaps.cs
@@ -53,7 +53,7 @@ namespace EpicLoot.Adventure.Feature
             return results.OrderBy(x => x.Cost).ToList();
         }
 
-        public IEnumerator SpawnTreasureChest(Heightmap.Biome biome, Player player, Action<bool, Vector3> callback)
+        public IEnumerator SpawnTreasureChest(Heightmap.Biome biome, Player player, int price, Action<int, bool, Vector3> callback)
         {
             player.Message(MessageHud.MessageType.Center, "$mod_epicloot_treasuremap_locatingmsg");
             var saveData = player.GetAdventureSaveData();
@@ -61,16 +61,17 @@ namespace EpicLoot.Adventure.Feature
             {
                 if (success)
                 {
-                    CreateTreasureChest(biome, player, spawnPoint, normal, saveData, callback);
+                    CreateTreasureChest(biome, player, price, spawnPoint, normal, saveData, callback);
                 }
                 else
                 {
-                    callback?.Invoke(false, Vector3.zero);
+                    callback?.Invoke(0, false, Vector3.zero);
                 }
             });
         }
         
-        private void CreateTreasureChest(Heightmap.Biome biome, Player player, Vector3 spawnPoint, Vector3 normal, AdventureSaveData saveData, Action<bool, Vector3> callback)
+        private void CreateTreasureChest(Heightmap.Biome biome, Player player, int price, Vector3 spawnPoint, Vector3 normal,
+            AdventureSaveData saveData, Action<int, bool, Vector3> callback)
         {
             const string treasureChestPrefabName = "piece_chest_wood";
             var treasureChestPrefab = ZNetScene.instance.GetPrefab(treasureChestPrefabName);
@@ -83,7 +84,7 @@ namespace EpicLoot.Adventure.Feature
             saveData.PurchasedTreasureMap(GetCurrentInterval(), biome, spawnPoint, offset);
             Minimap.instance.ShowPointOnMap(spawnPoint + offset);
 
-            callback?.Invoke(true, spawnPoint);
+            callback?.Invoke(price, true, spawnPoint);
         }
     }
 }

--- a/EpicLoot/src/Crafting/CraftingTabs.cs
+++ b/EpicLoot/src/Crafting/CraftingTabs.cs
@@ -1,13 +1,13 @@
 ﻿namespace EpicLoot.Crafting
 {
-    public enum CraftingTabType
+    /*public enum CraftingTabType
     {
         Crafting,
         Upgrade,
         Disenchant,
         Enchant,
         Augment
-    }
+    }*/
 
     public enum CraftingTabStyle
     {
@@ -17,7 +17,8 @@
         Angled
     }
 
-    public static class CraftingTabs
+    // TODO: Is this used anywhere?
+    /*public static class CraftingTabs
     {
         public static bool HaveRequirementsHelper(Player player, Piece.Requirement[] requirements, int qualityLevel)
         {
@@ -33,5 +34,5 @@
             }
             return true;
         }
-    }
+    }*/
 }

--- a/EpicLoot/src/Crafting/RecipesHelper.cs
+++ b/EpicLoot/src/Crafting/RecipesHelper.cs
@@ -29,7 +29,7 @@ namespace EpicLoot.Crafting
             }
         }
 
-        public static bool HaveRequirements(Player player, Piece.Requirement[] requirements, int qualityLevel)
+        /*public static bool HaveRequirements(Player player, Piece.Requirement[] requirements, int qualityLevel)
         {
             foreach (var resource in requirements)
             {
@@ -42,6 +42,6 @@ namespace EpicLoot.Crafting
                 }
             }
             return true;
-        }
+        }*/
     }
 }

--- a/EpicLoot/src/Crafting/TransferMagicalEffects.cs
+++ b/EpicLoot/src/Crafting/TransferMagicalEffects.cs
@@ -7,7 +7,6 @@ namespace EpicLoot.Crafting;
 
 public static class TransferMagicalEffects
 {
-
     private static bool IsDoCraft;
     private static ItemDrop.ItemData CraftedItem = null;
     private static List<ItemDrop.ItemData> ConsumedMagicItems = new ();
@@ -61,7 +60,8 @@ public static class TransferMagicalEffects
         }
     }
 
-    [HarmonyPatch(typeof(Inventory), nameof(Inventory.AddItem), new []{typeof(string), typeof(int), typeof(int), typeof(int), typeof(long),typeof(string),typeof(bool)})]
+    [HarmonyPatch(typeof(Inventory), nameof(Inventory.AddItem), new []{typeof(string), typeof(int), typeof(int),
+        typeof(int), typeof(long),typeof(string),typeof(bool)})]
     static class InventoryAddItemPatch
     {
         [UsedImplicitly]

--- a/EpicLoot/src/CraftingV2/EnchantingUIController.cs
+++ b/EpicLoot/src/CraftingV2/EnchantingUIController.cs
@@ -176,17 +176,23 @@ namespace EpicLoot.CraftingV2
             var inventory = player.GetInventory();
             var boundItems = new List<ItemDrop.ItemData>();
             inventory.GetBoundItems(boundItems);
-            foreach (var item in inventory.GetAllItems())
+            var items = InventoryManagement.Instance.GetAllItems();
+            if (items != null)
             {
-                if (!EpicLoot.ShowEquippedAndHotbarItemsInSacrificeTab.Value)
+                foreach (var item in items)
                 {
-                    if (item != null && item.m_equipped || boundItems.Contains(item))
+                    if (!EpicLoot.ShowEquippedAndHotbarItemsInSacrificeTab.Value &&
+                        (item != null && item.m_equipped || boundItems.Contains(item)))
+                    {
                         continue;
-                }
+                    }
 
-                var products = EnchantCostsHelper.GetSacrificeProducts(item);
-                if (products != null)
-                    result.Add(new InventoryItemListElement() { Item = item });
+                    var products = EnchantCostsHelper.GetSacrificeProducts(item);
+                    if (products != null)
+                    {
+                        result.Add(new InventoryItemListElement() { Item = item });
+                    }
+                }
             }
 
             return result;
@@ -264,9 +270,6 @@ namespace EpicLoot.CraftingV2
             var materialConversionAmount = float.IsNaN(featureValues.Item1) ? -1 : featureValues.Item1;
             var runestoneConversionAmount = float.IsNaN(featureValues.Item2) ? -1 : featureValues.Item2;
 
-            var player = Player.m_localPlayer;
-            var inventory = player.GetInventory();
-
             var result = new List<ConversionRecipeUnity>();
 
             foreach (var conversion in conversions)
@@ -330,14 +333,16 @@ namespace EpicLoot.CraftingV2
                         Amount = requiredAmount
                     });
 
-                    if (inventory.CountItems(reqItemDrop.m_itemData.m_shared.m_name) > 0)
+                    if (InventoryManagement.Instance.CountItem(reqItemDrop.m_itemData.m_shared.m_name) > 0)
                     {
                         hasSomeItems = true;
                     }
                 }
 
                 if (hasSomeItems)
+                {
                     result.Add(recipe);
+                }
             }
 
             return result;
@@ -350,7 +355,7 @@ namespace EpicLoot.CraftingV2
 
         private static List<InventoryItemListElement> GetEnchantableItems()
         {
-            return Player.m_localPlayer.GetInventory().GetAllItems()
+            return InventoryManagement.Instance.GetAllItems()
                 .Where( item => !item.IsMagic() && EpicLoot.CanBeMagicItem(item))
                 .Select( item => new InventoryItemListElement() { Item = item })
                 .ToList();
@@ -491,7 +496,7 @@ namespace EpicLoot.CraftingV2
 
         private static List<InventoryItemListElement> GetAugmentableItems()
         {
-            return Player.m_localPlayer.GetInventory().GetAllItems()
+            return InventoryManagement.Instance.GetAllItems()
                 .Where(item => item.CanBeAugmented())
                 .Select(item => new InventoryItemListElement() { Item = item })
                 .ToList();
@@ -655,7 +660,7 @@ namespace EpicLoot.CraftingV2
             var inventory = player.GetInventory();
             var boundItems = new List<ItemDrop.ItemData>();
             inventory.GetBoundItems(boundItems);
-            return Player.m_localPlayer.GetInventory().GetAllItems()
+            return InventoryManagement.Instance.GetAllItems()
                 .Where(item => !item.m_equipped && (EpicLoot.ShowEquippedAndHotbarItemsInSacrificeTab.Value || 
                     !boundItems.Contains(item)))
                 .Where(item => item.IsMagic(out var magicItem) && magicItem.CanBeDisenchanted())

--- a/EpicLoot/src/GamePatches/ItemDrop_Patch_MagicItemTooltip.cs
+++ b/EpicLoot/src/GamePatches/ItemDrop_Patch_MagicItemTooltip.cs
@@ -56,7 +56,7 @@ namespace EpicLoot
             var magicColor = magicItem.GetColorString();
             var itemTypeName = magicItem.GetItemTypeName(item.Extended());
 
-            var skillLevel = Player.m_localPlayer.GetSkillLevel(item.m_shared.m_skillType);
+            var skillLevel = localPlayer.GetSkillLevel(item.m_shared.m_skillType);
 
             text.Append($"<color={magicColor}>{magicItem.GetRarityDisplay()} {itemTypeName}</color>\n");
             if (item.IsLegendarySetItem())

--- a/EpicLoot/src/GamePatches/Terminal_Patch.cs
+++ b/EpicLoot/src/GamePatches/Terminal_Patch.cs
@@ -155,7 +155,7 @@ namespace EpicLoot
                 if (ZoneSystem.instance.FindClosestLocation("Vendor_BlackForest", player.transform.position, out var location))
                 {
                     Console.instance.AddString(location.m_position.ToString());
-                    //player.TeleportTo(location.m_position + Vector3.right * 5, player.transform.rotation, true);
+                    player.TeleportTo(location.m_position + Vector3.right * 5, player.transform.rotation, true);
                 }
             }), true);
             new Terminal.ConsoleCommand("gotom", "", (args =>
@@ -164,7 +164,7 @@ namespace EpicLoot
                 if (ZoneSystem.instance.FindClosestLocation("Vendor_BlackForest", player.transform.position, out var location))
                 {
                     Console.instance.AddString(location.m_position.ToString());
-                    //player.TeleportTo(location.m_position + Vector3.right * 5, player.transform.rotation, true);
+                    player.TeleportTo(location.m_position + Vector3.right * 5, player.transform.rotation, true);
                 }
             }), true);
             new Terminal.ConsoleCommand("globalkeys", "", (args =>
@@ -254,7 +254,8 @@ namespace EpicLoot
 
         private static IEnumerator TestTreasureMapCoroutine(AdventureSaveData saveData, Heightmap.Biome biome, Player player, int count)
         {
-            var biomes = new[] { Heightmap.Biome.Meadows, Heightmap.Biome.BlackForest, Heightmap.Biome.Swamp, Heightmap.Biome.Mountain, Heightmap.Biome.Plains };
+            var biomes = new[] { Heightmap.Biome.Meadows, Heightmap.Biome.BlackForest, Heightmap.Biome.Swamp,
+                Heightmap.Biome.Mountain, Heightmap.Biome.Plains };
 
             saveData.DebugMode = true;
             var startInterval = saveData.TreasureMaps.Count == 0 ? -1 : saveData.TreasureMaps.Min(x => x.Interval) - 1;
@@ -262,13 +263,13 @@ namespace EpicLoot
             {
                 saveData.IntervalOverride = startInterval - (i + 1);
                 var selectedBiome = biome == Heightmap.Biome.None ? biomes[UnityEngine.Random.Range(0, biomes.Length)] : biome;
-                yield return AdventureDataManager.TreasureMaps.SpawnTreasureChest(selectedBiome, player, OnTreasureChestSpawnComplete);
+                yield return AdventureDataManager.TreasureMaps.SpawnTreasureChest(selectedBiome, player, 0, OnTreasureChestSpawnComplete);
             }
             saveData.DebugMode = false;
             AdventureDataManager.CheatNumberOfBounties = -1;
         }
 
-        private static void OnTreasureChestSpawnComplete(bool success, Vector3 spawnPoint)
+        private static void OnTreasureChestSpawnComplete(int price, bool success, Vector3 spawnPoint)
         {
             var output = "> Failed to spawn treasure map chest";
             if (success)

--- a/EpicLoot/src/Loot/LootRoller.cs
+++ b/EpicLoot/src/Loot/LootRoller.cs
@@ -196,12 +196,12 @@ namespace EpicLoot
 
         public static bool AnyItemSpawnCheatsActive()
         {
-            return CheatRollingItem || CheatDisableGating || CheatForceMagicEffect || 
+            return CheatRollingItem || CheatDisableGating || CheatForceMagicEffect ||
                 !string.IsNullOrEmpty(CheatForceLegendary) || !string.IsNullOrEmpty(CheatForceMythic) ||
                 CheatEffectCount > 0;
         }
 
-        private static List<GameObject> RollLootTableInternal(LootTable lootTable, 
+        private static List<GameObject> RollLootTableInternal(LootTable lootTable,
             int level, string objectName, Vector3 dropPoint, bool initializeObject)
         {
             var results = new List<GameObject>();
@@ -341,7 +341,7 @@ namespace EpicLoot
                     }
                 }
 
-                var itemID = (CheatDisableGating) ? lootDrop.Item : GatedItemTypeHelper.GetGatedItemID(lootDrop.Item);
+                var itemID = (CheatDisableGating) ? lootDrop.Item : GatedItemTypeHelper.GetGatedItemID(lootDrop.Item, 0);
 
                 GameObject itemPrefab = null;
 

--- a/EpicLoot/src/Magic/MagicItemComponent.cs
+++ b/EpicLoot/src/Magic/MagicItemComponent.cs
@@ -247,6 +247,7 @@ namespace EpicLoot
 
         public static string GetDisplayName(this ItemDrop.ItemData itemData)
         {
+            // TODO: investigate
             var name = itemData.m_shared.m_name;
 
             if (itemData.IsMagic(out var magicItem) && !string.IsNullOrEmpty(magicItem.DisplayName))

--- a/EpicLoot/src/Magic/MagicItemEffects/MultiShot.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/MultiShot.cs
@@ -19,25 +19,24 @@ namespace EpicLoot.MagicItemEffects
             var player = (Player)__instance.m_character;
             var doubleShot = player.HasActiveMagicEffect(MagicEffectType.DoubleMagicShot);
             var tripleShot = player.HasActiveMagicEffect(MagicEffectType.TripleBowShot);
-            if (!doubleShot && !tripleShot)
-                return;
 
-            var itemType = __instance.GetWeapon()?.m_shared.m_itemType;
-            var skillType = __instance.GetWeapon()?.m_shared.m_skillType;
-
-            if (doubleShot && itemType == ItemDrop.ItemData.ItemType.TwoHandedWeapon && skillType == Skills.SkillType.ElementalMagic)
-            {
-                // The accuracy on the fireball staff is 1, so the projectiles appear right on top of each other,
-                // this forces them to appear distinct and still feels good (greater AOE in lieu of accuracy)
-                if (__instance.m_projectileAccuracy < 2)
-                    __instance.m_projectileAccuracy = 2;
-                __instance.m_projectiles = 2;
-            }
-            else if (tripleShot && itemType == ItemDrop.ItemData.ItemType.Bow && (skillType == Skills.SkillType.Bows || skillType == Skills.SkillType.Crossbows))
+            if (tripleShot)
             {
                 if (__instance.m_projectileAccuracy < 2)
+                {
                     __instance.m_projectileAccuracy = 2;
+                }
+
                 __instance.m_projectiles = 3;
+            }
+            else if (doubleShot)
+            {
+                if (__instance.m_projectileAccuracy < 2)
+                {
+                    __instance.m_projectileAccuracy = 2;
+                }
+
+                __instance.m_projectiles = 2;
             }
         }
     }


### PR DESCRIPTION
* Set fallback gambling Coins from 1 to 10000 when misconfigured.
* Tweaked default fallback items for the item info configuration.
* Set default maximum radius for Ashlands adventure spawns to 8000, should help with performance issues when spawning bounties and treasure chests.
* Bounties and treasure chest should no longer spawn in lava.
* Treasure chests now delete themselves (like tombstones) after fully looted.
* Tweaked code for buying treasure chests to prevent accidental multiple purchase.
* Added support for the nocost cheat for Epic Loot trader menu.
* Epic Loot trader menu now allows you to buy items (and do other interactions) with a full inventory. Items will drop at the player's feet.
* Reworked gating logic to fix bugs with some items dropping when not allowed.
* Simplified double and triple shot checks to improve other mod compatibilities.
* Reworked inventory management (checks, additions, removal) into a new class EpicLoot_UnityLib.InventoryManagement to improve other mod compatibilities.
* Re-enabled gotomerchant command to teleport the player again.
* Set the default value of the "Config Sync - Lock Config" configuration to true.